### PR TITLE
Fixed anonymous s3 and duplicate gages

### DIFF
--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -18,11 +18,11 @@ USGS_POINT_GEOMETRY = "s3://ciroh-rti-public-data/teehr-data-warehouse/common/ge
 
 
 def get_usgs_nwm30_crosswalk():
-    return pd.read_parquet(USGS_NWM30_XWALK)
+    return pd.read_parquet(USGS_NWM30_XWALK, storage_options={"client_kwargs":{"region_name":"us-east-2"},"anon":True})
 
 
 def get_usgs_point_geometry():
-    return gpd.read_parquet(USGS_POINT_GEOMETRY)
+    return gpd.read_parquet(USGS_POINT_GEOMETRY, storage_options={"client_kwargs":{"region_name":"us-east-2"},"anon":True})
 
 
 def get_simulation_output_csv(wb_id, folder_to_eval):
@@ -75,6 +75,9 @@ def get_gages_from_hydrofabric(folder_to_eval):
         results = conn.execute(
             "SELECT id, rl_gages FROM flowpath_attributes WHERE rl_gages IS NOT NULL"
         ).fetchall()
+    # Fixme Take only the first result if a gage shows up more than once.
+    # Should be fixed upstream in hydrofabric with only error handling here.
+    results = [(r[0],r[1].split(',')[0]) for r in results]
     return results
 
 


### PR DESCRIPTION
With these simple adjustments, I was able to get this working on an arbitrary ngen simulation package built with this tool:
https://github.com/CIROH-UA/NGIAB_data_preprocess

__Notes__
I made a change to the troute.yaml to output csv: `stream_output_type: .csv` this may not be necessary if we implement this in place of the nearly identical function for csv output reading in utils.py. https://github.com/JoshCu/ngiab_eval/blob/b39e5af6eb382d64f07a5c55a7acb0109dd26f8f/ngiab_eval/core.py#L109
The adjustment to the list of gages is necessary with the v2.1 hydrofabric because of anomalies that are (presumably) corrected in the v2.2 hydrofabric where some gages are listed twice due to geoprocessing ambiguities.
