### PR TITLE
Add support for hydrofabric version 2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,9 @@ ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 ENV PATH=$PATH:$JAVA_HOME/bin
 
 COPY requirements.txt requirements.txt
-RUN python -m pip install -r requirements.txt
+
+RUN pip install uv
+RUN uv pip install --no-cache-dir -r requirements.txt --system
 
 COPY scripts/ .
 


### PR DESCRIPTION
- Added a check for a table only present in version 2.2 of the hydrofabric
- fetch the gages from the hf depending on the version
- Added a check for the troute output format
- Renamed the netcdf time variable to match the field mappings used by the csv output

- Also added UV to the build dockerfile to speed it up a bit (unrelated to other changes and can be removed if needed)